### PR TITLE
Remove the Google analytics code from the template

### DIFF
--- a/wagtail_helpdesk/templates/wagtail_helpdesk/base.html
+++ b/wagtail_helpdesk/templates/wagtail_helpdesk/base.html
@@ -22,19 +22,6 @@
   {% endblock schema %}
 </head>
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-EZ555D7QSW"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag() {
-    dataLayer.push(arguments);
-  }
-
-  gtag('js', new Date());
-  gtag('config', 'G-EZ555D7QSW', {'anonymize_ip': true, 'allow_ad_personalization_signals': false});
-</script>
-
 <body class="wagtail_helpdesk" data-controller="navigation">
 {% block navbar %}
   {% include "wagtail_helpdesk/includes/navbar.html" %}


### PR DESCRIPTION
Note that in this template, the code was placed outside the <head> section. Unsure whether this ever has worked.